### PR TITLE
Fix: allow base64-encoded image requests that contain "/"

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,9 @@
+cd ./deployment
+
+VERSION=2020-08-30
+
+./build-s3-dist.sh serverless-image-handler-nutmeg serverless-image-handler $VERSION
+
+aws s3 cp ./regional-s3-assets/ s3://serverless-image-handler-nutmeg-us-west-1/serverless-image-handler/$VERSION/ --recursive --acl bucket-owner-full-control
+
+# After the template and code are uploaded, the Cloudformation stack can be updated in the AWS console (us-west-1)

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -240,8 +240,8 @@ class ImageRequest {
     decodeRequest(event) {
         const path = event["path"];
         if (path !== undefined) {
-            const splitPath = path.split("/");
-            const encoded = splitPath[splitPath.length - 1];
+            // Eat the leading "/"
+            const encoded = path.splice(1);
             const toBuffer = Buffer.from(encoded, 'base64');
             try {
                 // To support European characters, 'ascii' was removed.

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -241,7 +241,7 @@ class ImageRequest {
         const path = event["path"];
         if (path !== undefined) {
             // Eat the leading "/"
-            const encoded = path.slice(1);
+            const encoded = path[0] === "/" ? path.slice(1) : path;
             const toBuffer = Buffer.from(encoded, 'base64');
             try {
                 // To support European characters, 'ascii' was removed.

--- a/source/image-handler/image-request.js
+++ b/source/image-handler/image-request.js
@@ -241,7 +241,7 @@ class ImageRequest {
         const path = event["path"];
         if (path !== undefined) {
             // Eat the leading "/"
-            const encoded = path.splice(1);
+            const encoded = path.slice(1);
             const toBuffer = Buffer.from(encoded, 'base64');
             try {
                 // To support European characters, 'ascii' was removed.


### PR DESCRIPTION
- fixing by changing from split on "/" to just eating the leading "/"
- also, added a deploy script for our usage